### PR TITLE
Add support for Steam tokens

### DIFF
--- a/qml/YubiKeyAuthListItem.qml
+++ b/qml/YubiKeyAuthListItem.qml
@@ -10,6 +10,7 @@ ListItem {
     property int type
     property alias name: nameLabel.text
     property string password
+    property bool steam
     property bool favorite
     property bool expired
     property bool refreshable
@@ -69,7 +70,7 @@ ListItem {
                 bold: favorite
             }
             truncationMode: TruncationMode.Fade
-            text: type === YubiKeyCard.TypeTOTP ? "TOTP" : "HOTP"
+            text: steam ? "Steam" : type === YubiKeyCard.TypeTOTP ? "TOTP" : "HOTP"
         }
     }
 

--- a/qml/YubiKeyPage.qml
+++ b/qml/YubiKeyPage.qml
@@ -409,6 +409,7 @@ Page {
                         readonly property string itemName: model.name
                         readonly property string itemPassword: model.password
                         readonly property bool itemFavorite: model.favorite
+                        readonly property bool itemCanBeSteamToken: model.type === YubiKeyCard.TypeTOTP
                         readonly property bool itemMarkedForRefresh: model.markedForRefresh
                         readonly property bool itemMarkedForDeletion: model.markedForDeletion
                         readonly property bool itemCanCopyPassword: !itemMarkedForRefresh && !itemMarkedForDeletion && itemPassword !== ""
@@ -419,6 +420,7 @@ Page {
                         name: itemName
                         type: model.type
                         password: itemPassword
+                        steam: model.steam
                         favorite: itemFavorite
                         expired: model.expired
                         refreshable: model.refreshable
@@ -438,16 +440,6 @@ Page {
                                     if (bottom > flickable.height) {
                                         flickable.contentY += bottom - flickable.height
                                     }
-                                }
-                                MenuItem {
-                                    id: copyMenuItem
-
-                                    //: Context menu item (copy password to clipboard)
-                                    //% "Copy password"
-                                    text: qsTrId("yubikey-menu-copy_password")
-                                    onEnabledChanged: contextMenu.updateVisibility()
-                                    enabled: delegate.itemCanCopyPassword
-                                    onClicked: delegate.copyPassword()
                                 }
                                 MenuItem {
                                     id: renameMenuItem
@@ -497,17 +489,31 @@ Page {
                                     enabled: !delegate.itemMarkedForDeletion
                                     onClicked: delegate.toggleFavorite()
                                 }
+                                MenuItem {
+                                    id: steamMenuItem
+
+                                    text: model.steam ?
+                                        //: Context menu item
+                                        //% "Standard token"
+                                        qsTrId("yubikey-menu-use_as_standard_token") :
+                                        //: Context menu item
+                                        //% "Steam token"
+                                        qsTrId("yubikey-menu-use_as_steam_token")
+                                    onEnabledChanged: contextMenu.updateVisibility()
+                                    enabled: delegate.itemCanBeSteamToken && !delegate.itemMarkedForDeletion
+                                    onClicked: model.steam = !model.steam
+                                }
 
                                 Component.onCompleted: updateVisibility()
                                 onMenuExpandedChanged: updateVisibility()
 
                                 function updateVisibility() {
                                     if (!menuExpanded) {
-                                        copyMenuItem.visible = copyMenuItem.enabled
                                         renameMenuItem.visible = renameMenuItem.enabled
                                         deleteMenuItem.visible = deleteMenuItem.enabled
                                         cancelMenuItem.visible = cancelMenuItem.enabled
                                         favoriteMenuItem.visible = favoriteMenuItem.enabled
+                                        steamMenuItem.visible = steamMenuItem.enabled
                                     }
                                 }
                             }

--- a/qml/YubiKeyTokenDialog.qml
+++ b/qml/YubiKeyTokenDialog.qml
@@ -78,7 +78,7 @@ Dialog {
 
                     width: counterField.visible ? parent.columnWidth : parent.width
                     //: Text field label (number of password digits)
-                    //% "Digits"
+                    //% "Digits (leave it 6 for Steam tokens)"
                     label: qsTrId("yubikey-token-digits-text")
                     //: Text field placeholder (number of password digits)
                     //% "Number of password digits"

--- a/src/YubiKeyCardSettings.h
+++ b/src/YubiKeyCardSettings.h
@@ -36,6 +36,7 @@
 #define _YUBIKEY_CARD_SETTINGS_H
 
 #include <QObject>
+#include <QStringList>
 
 class YubiKeyCardSettings :
     public QObject
@@ -52,10 +53,18 @@ public:
     bool isFavoriteName(const QString) const;
     void setFavoriteName(const QString);
     void clearFavorite();
+
+    QStringList steamHashes() const;
+    bool isSteamHash(const QString) const;
+    void setSteamHashes(const QStringList);
+    void addSteamHash(const QString);
+    void removeSteamHash(const QString);
+
     void tokenRenamed(const QString, const QString);
 
 Q_SIGNALS:
     void favoriteHashChanged();
+    void steamHashesChanged();
 
 private:
     class Private;

--- a/src/YubiKeyUtil.cpp
+++ b/src/YubiKeyUtil.cpp
@@ -64,10 +64,22 @@ YubiKeyUtil::configDir(
 }
 
 QString
-YubiKeyUtil::nameHashUtf8(
+YubiKeyUtil::hashUtf8(
     const QByteArray& aUtf8)
 {
     return QCryptographicHash::hash(aUtf8, QCryptographicHash::Sha1).toHex();
+}
+
+QString
+YubiKeyUtil::steamHashUtf8(
+    const QByteArray& aUtf8)
+{
+    // The same name gets a different hash for Steam and Favorite purposes
+    static QByteArray STEAM_PREFIX("steam:");
+    QCryptographicHash hash(QCryptographicHash::Sha1);
+    hash.addData(STEAM_PREFIX);
+    hash.addData(aUtf8);
+    return hash.result().toHex();
 }
 
 uint

--- a/src/YubiKeyUtil.h
+++ b/src/YubiKeyUtil.h
@@ -70,9 +70,12 @@ public:
     static QDir configDir();
     static QDir configDir(const QByteArray);
 
-    static QString nameHashUtf8(const QByteArray&);
+    static QString hashUtf8(const QByteArray&);
+    static QString steamHashUtf8(const QByteArray&);
+    static QString steamNameHash(const QString& aName)
+        { return steamHashUtf8(aName.toUtf8()); }
     static QString nameHash(const QString& aName)
-        { return nameHashUtf8(aName.toUtf8()); }
+        { return hashUtf8(aName.toUtf8()); }
 
     static uint versionToNumber(const uchar*, gsize);
     static inline uint versionToNumber(const QByteArray& aData)

--- a/translations/harbour-yubikey-ru.ts
+++ b/translations/harbour-yubikey-ru.ts
@@ -48,10 +48,10 @@
         <extracomment>Pulley menu item</extracomment>
         <translation>Убрать пароль</translation>
     </message>
-    <message id="yubikey-menu-copy_password">
-        <source>Copy password</source>
-        <extracomment>Context menu item (copy password to clipboard)</extracomment>
-        <translation>Скопировать пароль</translation>
+    <message id="yubikey-menu-edit">
+        <source>Edit</source>
+        <extracomment>Generic menu item</extracomment>
+        <translation>Изменить</translation>
     </message>
     <message id="yubikey-menu-rename">
         <source>Rename</source>
@@ -83,10 +83,15 @@
         <extracomment>Context menu item</extracomment>
         <translation>Убрать с обложки</translation>
     </message>
-    <message id="yubikey-menu-edit">
-        <source>Edit</source>
-        <extracomment>Generic menu item</extracomment>
-        <translation>Изменить</translation>
+    <message id="yubikey-menu-use_as_standard_token">
+        <source>Standard token</source>
+        <extracomment>Context menu item</extracomment>
+        <translation>Стандартный пароль</translation>
+    </message>
+    <message id="yubikey-menu-use_as_steam_token">
+        <source>Steam token</source>
+        <extracomment>Context menu item</extracomment>
+        <translation>Пароль Steam</translation>
     </message>
     <message id="yubikey-status-waiting_to_reset">
         <source>Touch the same YubiKey to reset it</source>
@@ -249,9 +254,9 @@
         <translation>%1 (по умолчанию)</translation>
     </message>
     <message id="yubikey-token-digits-text">
-        <source>Digits</source>
+        <source>Digits (leave it 6 for Steam tokens)</source>
         <extracomment>Text field label (number of password digits)</extracomment>
-        <translation>Длина пароля</translation>
+        <translation>Длина пароля (оставьте 6 для паролей Steam)</translation>
     </message>
     <message id="yubikey-token-digits-placeholder">
         <source>Number of password digits</source>

--- a/translations/harbour-yubikey-sv.ts
+++ b/translations/harbour-yubikey-sv.ts
@@ -48,10 +48,10 @@
         <extracomment>Pulley menu item</extracomment>
         <translation>Ta bort lösenord</translation>
     </message>
-    <message id="yubikey-menu-copy_password">
-        <source>Copy password</source>
-        <extracomment>Context menu item (copy password to clipboard)</extracomment>
-        <translation>Kopiera lösenord</translation>
+    <message id="yubikey-menu-edit">
+        <source>Edit</source>
+        <extracomment>Generic menu item</extracomment>
+        <translation>Redigera</translation>
     </message>
     <message id="yubikey-menu-rename">
         <source>Rename</source>
@@ -83,10 +83,15 @@
         <extracomment>Context menu item</extracomment>
         <translation>Ta bort från programminiatyr</translation>
     </message>
-    <message id="yubikey-menu-edit">
-        <source>Edit</source>
-        <extracomment>Generic menu item</extracomment>
-        <translation>Redigera</translation>
+    <message id="yubikey-menu-use_as_standard_token">
+        <source>Standard token</source>
+        <extracomment>Context menu item</extracomment>
+        <translation type="unfinished">Standard token</translation>
+    </message>
+    <message id="yubikey-menu-use_as_steam_token">
+        <source>Steam token</source>
+        <extracomment>Context menu item</extracomment>
+        <translation type="unfinished">Steam-token</translation>
     </message>
     <message id="yubikey-status-waiting_to_reset">
         <source>Touch the same YubiKey to reset it</source>
@@ -249,9 +254,9 @@
         <translation>%1 (standard)</translation>
     </message>
     <message id="yubikey-token-digits-text">
-        <source>Digits</source>
+        <source>Digits (leave it 6 for Steam tokens)</source>
         <extracomment>Text field label (number of password digits)</extracomment>
-        <translation>Siffror</translation>
+        <translation type="unfinished">Siffror (låt det vara 6 för Steam-tokens)</translation>
     </message>
     <message id="yubikey-token-digits-placeholder">
         <source>Number of password digits</source>

--- a/translations/harbour-yubikey.ts
+++ b/translations/harbour-yubikey.ts
@@ -48,10 +48,10 @@
         <extracomment>Pulley menu item</extracomment>
         <translation>Clear password</translation>
     </message>
-    <message id="yubikey-menu-copy_password">
-        <source>Copy password</source>
-        <extracomment>Context menu item (copy password to clipboard)</extracomment>
-        <translation>Copy password</translation>
+    <message id="yubikey-menu-edit">
+        <source>Edit</source>
+        <extracomment>Generic menu item</extracomment>
+        <translation>Edit</translation>
     </message>
     <message id="yubikey-menu-rename">
         <source>Rename</source>
@@ -83,10 +83,15 @@
         <extracomment>Context menu item</extracomment>
         <translation>Remove from cover</translation>
     </message>
-    <message id="yubikey-menu-edit">
-        <source>Edit</source>
-        <extracomment>Generic menu item</extracomment>
-        <translation>Edit</translation>
+    <message id="yubikey-menu-use_as_standard_token">
+        <source>Standard token</source>
+        <extracomment>Context menu item</extracomment>
+        <translation>Standard token</translation>
+    </message>
+    <message id="yubikey-menu-use_as_steam_token">
+        <source>Steam token</source>
+        <extracomment>Context menu item</extracomment>
+        <translation>Steam token</translation>
     </message>
     <message id="yubikey-status-waiting_to_reset">
         <source>Touch the same YubiKey to reset it</source>
@@ -249,9 +254,9 @@
         <translation>%1 (default)</translation>
     </message>
     <message id="yubikey-token-digits-text">
-        <source>Digits</source>
+        <source>Digits (leave it 6 for Steam tokens)</source>
         <extracomment>Text field label (number of password digits)</extracomment>
-        <translation>Digits</translation>
+        <translation>Digits (leave it 6 for Steam tokens)</translation>
     </message>
     <message id="yubikey-token-digits-placeholder">
         <source>Number of password digits</source>


### PR DESCRIPTION
The steam option can be turned on for a TOTP token via context menu:

![image](https://user-images.githubusercontent.com/5909522/235545544-2ee5a839-d8c8-46b8-9bbd-3d76f5b64980.png)

and it goes like this:

![image](https://user-images.githubusercontent.com/5909522/235545950-5243bf60-6eda-4596-9059-bac3e762d7e3.png)

Pre-built rpms: [harbour-yubikey-1.0.7+steam.20230501223509.2.gee2a499-1.zip](https://github.com/monich/harbour-yubikey/files/11368506/harbour-yubikey-1.0.7%2Bsteam.20230501223509.2.gee2a499-1.zip)
